### PR TITLE
Add poster download and embed metadata in videos and category download support with limit option 

### DIFF
--- a/.github/workflows/dev.release.yml
+++ b/.github/workflows/dev.release.yml
@@ -28,12 +28,10 @@ jobs:
 
       - name: Create dev release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: 0.0.0-dev
-          release_name: Development Build
+          name: 0.0.0-dev (Development Build)
           body: |
             ⚠️ **Development Build** - Built from latest `main` branch.
 
@@ -41,7 +39,8 @@ jobs:
 
             Built from commit: ${{ github.sha }}
           draft: false
-          prerelease: true
+          prerelease: false
+          make_latest: true
 
   # Step 3 & 4: Build and upload artifacts
   build-and-upload:

--- a/.github/workflows/dev.release.yml
+++ b/.github/workflows/dev.release.yml
@@ -11,42 +11,10 @@ permissions:
   packages: write
 
 jobs:
-  # Step 1 & 2: Delete old release and create new one
-  create-release:
-    name: Create Dev Release
+  # Step 1: Build all binaries
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Delete existing dev release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release delete 0.0.0-dev --yes --cleanup-tag || true
-
-      - name: Create dev release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: 0.0.0-dev
-          name: 0.0.0-dev (Development Build)
-          body: |
-            ⚠️ **Development Build** - Built from latest `main` branch.
-
-            This is an unstable development release. Use at your own risk.
-
-            Built from commit: ${{ github.sha }}
-          draft: false
-          prerelease: false
-          make_latest: true
-
-  # Step 3 & 4: Build and upload artifacts
-  build-and-upload:
-    name: Build and Upload
-    runs-on: ubuntu-latest
-    needs: create-release
     strategy:
       matrix:
         goos: [linux, darwin, windows, freebsd]
@@ -78,12 +46,47 @@ jobs:
         run: |
           tar -czf masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz masterclass-dl
 
-      - name: Upload to Release
-        uses: actions/upload-release-asset@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ./masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
+
+  # Step 2: Delete old release, create new one, upload all artifacts
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la artifacts/
+
+      - name: Delete existing dev release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete 0.0.0-dev --yes --cleanup-tag || true
+
+      - name: Create release and upload assets
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
-          asset_name: masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
-          asset_content_type: application/octet-stream
+          tag_name: 0.0.0-dev
+          name: 0.0.0-dev (Development Build)
+          body: |
+            ⚠️ **Development Build** - Built from latest `main` branch.
+
+            This is an unstable development release. Use at your own risk.
+
+            Built from commit: ${{ github.sha }}
+          draft: false
+          prerelease: false
+          make_latest: true
+          files: artifacts/*

--- a/.github/workflows/dev.release.yml
+++ b/.github/workflows/dev.release.yml
@@ -1,0 +1,90 @@
+# Dev release workflow - builds and publishes 0.0.0-dev on every push to main
+name: Dev Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # Step 1 & 2: Delete old release and create new one
+  create-release:
+    name: Create Dev Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete existing dev release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete 0.0.0-dev --yes --cleanup-tag || true
+
+      - name: Create dev release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 0.0.0-dev
+          release_name: Development Build
+          body: |
+            ⚠️ **Development Build** - Built from latest `main` branch.
+
+            This is an unstable development release. Use at your own risk.
+
+            Built from commit: ${{ github.sha }}
+          draft: false
+          prerelease: true
+
+  # Step 3 & 4: Build and upload artifacts
+  build-and-upload:
+    name: Build and Upload
+    runs-on: ubuntu-latest
+    needs: create-release
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows, freebsd]
+        goarch: [amd64, 386, arm64, arm]
+        exclude:
+          - goos: darwin
+            goarch: 386
+          - goos: darwin
+            goarch: arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -ldflags="-s -w" -o masterclass-dl${{ matrix.goos == 'windows' && '.exe' || '' }}
+
+      - name: Archive Zip
+        if: matrix.goos == 'windows'
+        run: |
+          7z a -tzip masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}.zip masterclass-dl.exe
+
+      - name: Archive Tar
+        if: matrix.goos != 'windows'
+        run: |
+          tar -czf masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz masterclass-dl
+
+      - name: Upload to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
+          asset_name: masterclass-dl-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.zip' || '.tar.gz' }}
+          asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download the executable from the [releases](https://github.com/RythenGlyth/maste
 Or build from source:
 ```bash
 go build -o masterclass-dl .
-```˚
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ masterclass-dl download -o ./downloads --limit 0 "https://www.masterclass.com/ho
 | `--output` | `-o` | (required) | Output directory |
 | `--limit` | `-l` | 10 | Max classes to download from a category (0 = unlimited) |
 | `--pdfs` | `-p` | true | Download PDF workbooks |
-| `--posters` | | true | Download poster and fanart images |
+| `--posters` | | true | Download poster and fanart images 
 | `--ytdl-exec` | `-y` | yt-dlp | Path to yt-dlp/youtube-dl executable |
 | `--name-files-as-series` | | false | Name files in TV series format for Plex/Jellyfin |
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ masterclass-dl download -o ./downloads --limit 0 "https://www.masterclass.com/ho
 | `--pdfs` | `-p` | true | Download PDF workbooks |
 | `--posters` | | true | Download poster and fanart images |
 | `--ytdl-exec` | `-y` | yt-dlp | Path to yt-dlp/youtube-dl executable |
+| `--name-files-as-series` | | false | Name files in TV series format for Plex/Jellyfin |
 
 #### Examples
 
 ```bash
+# Download with Plex-friendly TV series naming (s01e01-Title.mp4)
+masterclass-dl download -o ./downloads --name-files-as-series "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
+
 # Download without PDFs
 masterclass-dl download -o ./downloads --pdfs=false "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
 
@@ -92,23 +96,44 @@ masterclass-dl download -o ./downloads -y /usr/local/bin/yt-dlp "https://www.mas
 
 Downloads are organized in a Plex/Jellyfin-friendly format:
 
+**Default naming:**
 ```
 downloads/
 ├── Gordon Ramsay Teaches Cooking/
-│   ├── poster.jpg              # 2x3 vertical artwork (for Plex/Jellyfin)
-│   ├── fanart.jpg              # 16x9 horizontal artwork (for backgrounds)
-│   ├── Class Guide.pdf         # Workbook/PDF materials
-│   ├── 001-Introduction.mp4    # Video with embedded subtitles
+│   ├── poster.jpg
+│   ├── fanart.jpg
+│   ├── Class Guide.pdf
+│   ├── 001-Introduction.mp4
 │   ├── 002-Knives.mp4
 │   └── ...
-└── Neil deGrasse Tyson.../
-    └── ...
+```
+
+**With `--name-files-as-series`:**
+```
+downloads/
+├── Gordon Ramsay Teaches Cooking/
+│   ├── poster.jpg
+│   ├── fanart.jpg
+│   ├── Class Guide.pdf
+│   ├── s01e01-Introduction.mp4
+│   ├── s01e02-Knives.mp4
+│   ├── s01e15-Closing-Extra_trailer.mp4  # Example lessons marked as extras
+│   └── ...
 ```
 
 **Video features:**
 - Embedded subtitles in 10+ languages (English, Spanish, French, German, Italian, Japanese, Chinese, Hindi, Polish, Portuguese)
 - Best available video/audio quality
 - Metadata embedded (title, description, episode number)
+
+**With `--name-files-as-series`, additional metadata:**
+- `show` - Series/course title
+- `artist` - Instructor name
+- `genre` - Category (e.g., "Arts & Entertainment")
+- `date` - Episode date
+- `episode_id` - s01e01 format
+- `network` - "MasterClass"
+- `synopsis` - Course overview
 
 ## Global Flags
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,132 @@
 
 A command line tool to download masterclass.com classes.
 
-# Prerequisites
+## Features
 
-- youtube-dl or yt-dlp
+- **Download entire categories** - Bulk download all classes from any category page
+- **Plex-ready output** - Poster (`poster.jpg`) and fanart (`fanart.jpg`) images for media servers
+- **Embedded subtitles** - 10+ languages automatically embedded in videos
+- **PDF workbooks** - Class guides and supplementary materials
+- **Flexible options** - Control what gets downloaded with `--pdfs`, `--posters`, `--limit`
+
+## Prerequisites
+
+- yt-dlp (recommended) or youtube-dl
 - ffmpeg
 
-# Installation
+## Installation
 
-Download the executabe from the [releases](https://github.com/RythenGlyth/masterclass-dl/releases) page.
+Download the executable from the [releases](https://github.com/RythenGlyth/masterclass-dl/releases) page.
 
-# Usage
+Or build from source:
+```bash
+go build -o masterclass-dl .
+```
+
+## Usage
+
+### Login
+
+First, authenticate with your Masterclass account:
+
+```bash
+masterclass-dl login <email> <password>
+```
+
+You'll be prompted to select a profile if your account has multiple profiles.
+
+### Check Status
+
+Verify your login and subscription status:
+
+```bash
+masterclass-dl status
+```
+
+### Download
+
+Download individual classes, specific chapters, or **bulk download entire categories**:
+
+```bash
+# Download a single class
+masterclass-dl download -o ./downloads "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
+
+# Download a specific chapter
+masterclass-dl download -o ./downloads "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking/chapters/introduction"
+
+# Download all classes in a category (first 10 by default)
+masterclass-dl download -o ./downloads "https://www.masterclass.com/homepage/science-and-tech"
+
+# Download all classes in a category (no limit)
+masterclass-dl download -o ./downloads --limit 0 "https://www.masterclass.com/homepage/science-and-tech"
+```
+
+#### Download Options
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output` | `-o` | (required) | Output directory |
+| `--limit` | `-l` | 10 | Max classes to download from a category (0 = unlimited) |
+| `--pdfs` | `-p` | true | Download PDF workbooks |
+| `--posters` | | true | Download poster and fanart images |
+| `--ytdl-exec` | `-y` | yt-dlp | Path to yt-dlp/youtube-dl executable |
+
+#### Examples
+
+```bash
+# Download without PDFs
+masterclass-dl download -o ./downloads --pdfs=false "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
+
+# Download without poster images
+masterclass-dl download -o ./downloads --posters=false "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
+
+# Download first 5 classes from a category
+masterclass-dl download -o ./downloads --limit 5 "https://www.masterclass.com/homepage/science-and-tech"
+
+# Use a specific yt-dlp path
+masterclass-dl download -o ./downloads -y /usr/local/bin/yt-dlp "https://www.masterclass.com/classes/gordon-ramsay-teaches-cooking"
+```
+
+### Output Structure
+
+Downloads are organized in a Plex/Jellyfin-friendly format:
 
 ```
-A downloader for classes from masterclass.com
+downloads/
+├── Gordon Ramsay Teaches Cooking/
+│   ├── poster.jpg              # 2x3 vertical artwork (for Plex/Jellyfin)
+│   ├── fanart.jpg              # 16x9 horizontal artwork (for backgrounds)
+│   ├── Class Guide.pdf         # Workbook/PDF materials
+│   ├── 001-Introduction.mp4    # Video with embedded subtitles
+│   ├── 002-Knives.mp4
+│   └── ...
+└── Neil deGrasse Tyson.../
+    └── ...
+```
 
-Usage:
-  masterclass-dl [command]
+**Video features:**
+- Embedded subtitles in 10+ languages (English, Spanish, French, German, Italian, Japanese, Chinese, Hindi, Polish, Portuguese)
+- Best available video/audio quality
+- Metadata embedded (title, description, episode number)
+
+## Global Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--datDir` | `-d` | ~/.masterclass/ | Directory for cookies and data |
+| `--debug` | | false | Enable debug output |
+
+## Commands Reference
+
+```
+masterclass-dl [command]
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
-  download    Download a class or chapter from masterclass.com
+  download    Download a class, chapter, or category from masterclass.com
   help        Help about any command
   login       Login to masterclass.com
   status      Check login status
 
-Flags:
-  -d, --datDir string   Path to the directory where cookies and other data will be stored (default: $HOME/.masterclass/)
-  -h, --help            help for masterclass-dl
-
 Use "masterclass-dl [command] --help" for more information about a command.
 ```
-

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download the executable from the [releases](https://github.com/RythenGlyth/maste
 Or build from source:
 ```bash
 go build -o masterclass-dl .
-```
+```˚
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ masterclass-dl download -o ./downloads --limit 0 "https://www.masterclass.com/ho
 | `--output` | `-o` | (required) | Output directory |
 | `--limit` | `-l` | 10 | Max classes to download from a category (0 = unlimited) |
 | `--pdfs` | `-p` | true | Download PDF workbooks |
-| `--posters` | | true | Download poster and fanart images 
+| `--posters` | | true | Download poster and fanart images |
 | `--ytdl-exec` | `-y` | yt-dlp | Path to yt-dlp/youtube-dl executable |
 | `--name-files-as-series` | | false | Name files in TV series format for Plex/Jellyfin |
+| `--write-nfo` | | false | Generate NFO metadata files alongside downloads |
+| `--metadata-only` | | false | Download only metadata (no videos or PDFs) |
+| `--force` | | false | Force re-download and overwrite existing files |
+| `--concurrency` | | 1 | Number of concurrent downloads to run |
 
 #### Examples
 

--- a/main.go
+++ b/main.go
@@ -1492,14 +1492,31 @@ func writeNFO(course CourseResponse, outputDir string) error {
 		tags = append(tags, course.Skill)
 	}
 
-	// Split instructor names and build actor list
-	instructorNames := splitInstructorNames(course.InstructorName)
+	// Build actor list from instructors array (preferred) or fall back to splitting instructor_name
 	var actors []NFOActor
-	for _, name := range instructorNames {
-		actors = append(actors, NFOActor{
-			Name: name,
-			Role: "Instructor",
-		})
+	if len(course.Instructors) > 0 {
+		for _, inst := range course.Instructors {
+			actor := NFOActor{
+				Name: inst.Name,
+				Role: "Instructor",
+			}
+			// Add headshot if available
+			if inst.HeadshotURL != nil {
+				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
+					actor.Thumb = headshot
+				}
+			}
+			actors = append(actors, actor)
+		}
+	} else {
+		// Fallback: split instructor_name string
+		instructorNames := splitInstructorNames(course.InstructorName)
+		for _, name := range instructorNames {
+			actors = append(actors, NFOActor{
+				Name: name,
+				Role: "Instructor",
+			})
+		}
 	}
 
 	// Build the NFO struct

--- a/main.go
+++ b/main.go
@@ -1621,8 +1621,17 @@ func writeNFO(course CourseResponse, outputDir string) error {
 					actor.Bio = bio
 				}
 			}
-			// Use local portrait filename in .actors/ folder (Kodi/Plex standard)
-			actor.Thumb = ".actors/" + actorFilename(inst.Name) + ".jpg"
+			// Use headshot URL for actor thumb (Plex link mode)
+			// Local files are also saved to .actors/ for Kodi/local mode users
+			if inst.HeadshotURL != nil {
+				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
+					actor.Thumb = headshot + "?width=500&height=500&fit=cover&dpr=2"
+				}
+			}
+			// Fallback to poster if no headshot
+			if actor.Thumb == "" && course.Primary2x3 != "" {
+				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
+			}
 			actors = append(actors, actor)
 		}
 	}
@@ -1634,8 +1643,10 @@ func writeNFO(course CourseResponse, outputDir string) error {
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use local portrait filename in .actors/ folder
-			actor.Thumb = ".actors/" + actorFilename(name) + ".jpg"
+			// Use poster as fallback thumb URL
+			if course.Primary2x3 != "" {
+				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
+			}
 			actors = append(actors, actor)
 		}
 	}
@@ -1707,8 +1718,16 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 					actor.Bio = bio
 				}
 			}
-			// Use local portrait filename in .actors/ folder (Kodi/Plex standard)
-			actor.Thumb = ".actors/" + actorFilename(inst.Name) + ".jpg"
+			// Use headshot URL for actor thumb (Plex link mode)
+			if inst.HeadshotURL != nil {
+				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
+					actor.Thumb = headshot + "?width=500&height=500&fit=cover&dpr=2"
+				}
+			}
+			// Fallback to poster if no headshot
+			if actor.Thumb == "" && course.Primary2x3 != "" {
+				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
+			}
 			actors = append(actors, actor)
 		}
 	}
@@ -1720,8 +1739,10 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use local portrait filename in .actors/ folder
-			actor.Thumb = ".actors/" + actorFilename(name) + ".jpg"
+			// Use poster as fallback thumb URL
+			if course.Primary2x3 != "" {
+				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
+			}
 			actors = append(actors, actor)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1610,10 +1610,15 @@ func writeNFO(course CourseResponse, outputDir string) error {
 	hasValidInstructors := false
 	if len(course.Instructors) > 0 && course.Instructors[0].Name != "" {
 		hasValidInstructors = true
-		for _, inst := range course.Instructors {
+		numInstructors := len(course.Instructors)
+		for i, inst := range course.Instructors {
+			role := "Instructor"
+			if numInstructors > 1 {
+				role = fmt.Sprintf("Instructor %d", i+1)
+			}
 			actor := NFOActor{
 				Name: inst.Name,
-				Role: "Instructor",
+				Role: role,
 			}
 			// Add bio if available
 			if inst.Bio != nil {
@@ -1638,10 +1643,15 @@ func writeNFO(course CourseResponse, outputDir string) error {
 	if !hasValidInstructors {
 		// Fallback: split instructor_name string
 		instructorNames := splitInstructorNames(course.InstructorName)
-		for _, name := range instructorNames {
+		numInstructors := len(instructorNames)
+		for i, name := range instructorNames {
+			role := "Instructor"
+			if numInstructors > 1 {
+				role = fmt.Sprintf("Instructor %d", i+1)
+			}
 			actor := NFOActor{
 				Name: name,
-				Role: "Instructor",
+				Role: role,
 			}
 			// Use poster as fallback thumb URL
 			if course.Primary2x3 != "" {
@@ -1707,10 +1717,15 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 	hasValidInstructors := false
 	if len(course.Instructors) > 0 && course.Instructors[0].Name != "" {
 		hasValidInstructors = true
-		for _, inst := range course.Instructors {
+		numInstructors := len(course.Instructors)
+		for i, inst := range course.Instructors {
+			role := "Instructor"
+			if numInstructors > 1 {
+				role = fmt.Sprintf("Instructor %d", i+1)
+			}
 			actor := NFOActor{
 				Name: inst.Name,
-				Role: "Instructor",
+				Role: role,
 			}
 			// Add bio if available
 			if inst.Bio != nil {
@@ -1734,10 +1749,15 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 	if !hasValidInstructors {
 		// Fallback: split instructor_name string
 		instructorNames := splitInstructorNames(course.InstructorName)
-		for _, name := range instructorNames {
+		numInstructors := len(instructorNames)
+		for i, name := range instructorNames {
+			role := "Instructor"
+			if numInstructors > 1 {
+				role = fmt.Sprintf("Instructor %d", i+1)
+			}
 			actor := NFOActor{
 				Name: name,
-				Role: "Instructor",
+				Role: role,
 			}
 			// Use poster as fallback thumb URL
 			if course.Primary2x3 != "" {

--- a/main.go
+++ b/main.go
@@ -959,7 +959,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 		return err
 	}
 
-	outputDir = path.Join(outputDir, class.Title)
+	outputDir = path.Join(outputDir, sanitizeFilename(class.Title))
 	err = os.MkdirAll(outputDir, 0755)
 	if err != nil {
 		return err
@@ -1091,12 +1091,12 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 				var baseFileName string
 				if nameAsSeries {
 					if chapter.IsExampleLesson {
-						baseFileName = fmt.Sprintf("s01e%02d-%s-Extra_trailer", chapter.Number, chapter.Title)
+						baseFileName = fmt.Sprintf("s01e%02d-%s-Extra_trailer", chapter.Number, sanitizeFilename(chapter.Title))
 					} else {
-						baseFileName = fmt.Sprintf("s01e%02d-%s", chapter.Number, chapter.Title)
+						baseFileName = fmt.Sprintf("s01e%02d-%s", chapter.Number, sanitizeFilename(chapter.Title))
 					}
 				} else {
-					baseFileName = fmt.Sprintf("%03d-%s", chapter.Number, chapter.Title)
+					baseFileName = fmt.Sprintf("%03d-%s", chapter.Number, sanitizeFilename(chapter.Title))
 				}
 				nfoFilename := baseFileName + ".nfo"
 				err = writeEpisodeNFO(chapter, class, outputDir, nfoFilename)
@@ -1321,13 +1321,13 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 	if nameAsSeries {
 		// TV series format: s01e01-Title.mp4 or s01e01-Title-Extra_trailer.mp4
 		if chapter.IsExampleLesson {
-			baseFileName = fmt.Sprintf("s01e%02d-%s-Extra_trailer", chapter.Number, chapter.Title)
+			baseFileName = fmt.Sprintf("s01e%02d-%s-Extra_trailer", chapter.Number, sanitizeFilename(chapter.Title))
 		} else {
-			baseFileName = fmt.Sprintf("s01e%02d-%s", chapter.Number, chapter.Title)
+			baseFileName = fmt.Sprintf("s01e%02d-%s", chapter.Number, sanitizeFilename(chapter.Title))
 		}
 	} else {
 		// Default format: 001-Title.mp4
-		baseFileName = fmt.Sprintf("%03d-%s", chapter.Number, chapter.Title)
+		baseFileName = fmt.Sprintf("%03d-%s", chapter.Number, sanitizeFilename(chapter.Title))
 	}
 	outputFile := path.Join(outputDir, baseFileName+".mp4")
 

--- a/main.go
+++ b/main.go
@@ -938,8 +938,8 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 		return fmt.Errorf("invalid class slug")
 	}
 
-	//get class info
-	req, err := http.NewRequest("GET", "https://www.masterclass.com/jsonapi/v1/courses/"+classSlug+"?deep=true", nil)
+	//get class info (include=instructors ensures we get full instructor data for series)
+	req, err := http.NewRequest("GET", "https://www.masterclass.com/jsonapi/v1/courses/"+classSlug+"?deep=true&include=instructors", nil)
 	req.Header.Set("Referer", "https://www.masterclass.com/classes/"+classSlug)
 	req.Header.Set("Mc-Profile-Id", profile.UUID)
 	if err != nil {
@@ -986,9 +986,11 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 		for _, inst := range class.Instructors {
 			if inst.Name != "" && inst.HeadshotURL != nil {
 				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
+					// Add sizing params for higher quality portrait
+					headshotURL := headshot + "?width=500&height=500&fit=cover&dpr=2"
 					filename := sanitizeFilename(inst.Name) + ".jpg"
 					fmt.Printf("Downloading portrait: %s\n", inst.Name)
-					err = downloadImage(client, headshot, path.Join(outputDir, filename))
+					err = downloadImage(client, headshotURL, path.Join(outputDir, filename))
 					if err != nil {
 						fmt.Printf("Warning: failed to download portrait for %s: %v\n", inst.Name, err)
 					}

--- a/main.go
+++ b/main.go
@@ -982,7 +982,9 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 				fmt.Printf("Warning: failed to download fanart: %v\n", err)
 			}
 		}
-		// Download instructor portraits
+		// Download instructor portraits to .actors/ folder (Kodi/Plex standard)
+		actorsDir := path.Join(outputDir, ".actors")
+		os.MkdirAll(actorsDir, 0755)
 		for _, inst := range class.Instructors {
 			if inst.Name != "" {
 				var portraitURL string
@@ -996,9 +998,9 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 					portraitURL = class.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
 				}
 				if portraitURL != "" {
-					filename := sanitizeFilename(inst.Name) + ".jpg"
+					filename := actorFilename(inst.Name) + ".jpg"
 					fmt.Printf("Downloading portrait: %s\n", inst.Name)
-					err = downloadImage(client, portraitURL, path.Join(outputDir, filename))
+					err = downloadImage(client, portraitURL, path.Join(actorsDir, filename))
 					if err != nil {
 						fmt.Printf("Warning: failed to download portrait for %s: %v\n", inst.Name, err)
 					}
@@ -1439,6 +1441,14 @@ func sanitizeFilename(name string) string {
 	return replacer.Replace(name)
 }
 
+// actorFilename converts actor name to .actors/ folder format (spaces → underscores)
+// This matches XBMCnfoTVImporter.bundle expectations
+func actorFilename(name string) string {
+	// First sanitize, then replace spaces with underscores
+	sanitized := sanitizeFilename(name)
+	return strings.ReplaceAll(sanitized, " ", "_")
+}
+
 func downloadImage(client *http.Client, imageURL string, outputPath string) error {
 	resp, err := client.Get(imageURL)
 	if err != nil {
@@ -1611,8 +1621,8 @@ func writeNFO(course CourseResponse, outputDir string) error {
 					actor.Bio = bio
 				}
 			}
-			// Use local portrait filename (downloaded alongside NFO)
-			actor.Thumb = sanitizeFilename(inst.Name) + ".jpg"
+			// Use local portrait filename in .actors/ folder (Kodi/Plex standard)
+			actor.Thumb = ".actors/" + actorFilename(inst.Name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1624,8 +1634,8 @@ func writeNFO(course CourseResponse, outputDir string) error {
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use local portrait filename
-			actor.Thumb = sanitizeFilename(name) + ".jpg"
+			// Use local portrait filename in .actors/ folder
+			actor.Thumb = ".actors/" + actorFilename(name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1697,8 +1707,8 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 					actor.Bio = bio
 				}
 			}
-			// Use local portrait filename (downloaded alongside NFO)
-			actor.Thumb = sanitizeFilename(inst.Name) + ".jpg"
+			// Use local portrait filename in .actors/ folder (Kodi/Plex standard)
+			actor.Thumb = ".actors/" + actorFilename(inst.Name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1710,8 +1720,8 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use local portrait filename
-			actor.Thumb = sanitizeFilename(name) + ".jpg"
+			// Use local portrait filename in .actors/ folder
+			actor.Thumb = ".actors/" + actorFilename(name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1611,16 +1611,8 @@ func writeNFO(course CourseResponse, outputDir string) error {
 					actor.Bio = bio
 				}
 			}
-			// Add headshot URL (Plex/Kodi need full URL, not local filename)
-			if inst.HeadshotURL != nil {
-				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
-					actor.Thumb = headshot + "?width=500&height=500&fit=cover&dpr=2"
-				}
-			}
-			// Fallback to poster image if no headshot
-			if actor.Thumb == "" && course.Primary2x3 != "" {
-				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
-			}
+			// Use local portrait filename (downloaded alongside NFO)
+			actor.Thumb = sanitizeFilename(inst.Name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1632,10 +1624,8 @@ func writeNFO(course CourseResponse, outputDir string) error {
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use poster as fallback for actor thumb
-			if course.Primary2x3 != "" {
-				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
-			}
+			// Use local portrait filename
+			actor.Thumb = sanitizeFilename(name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1707,16 +1697,8 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 					actor.Bio = bio
 				}
 			}
-			// Add headshot URL
-			if inst.HeadshotURL != nil {
-				if headshot, ok := inst.HeadshotURL.(string); ok && headshot != "" {
-					actor.Thumb = headshot + "?width=500&height=500&fit=cover&dpr=2"
-				}
-			}
-			// Fallback to poster image if no headshot
-			if actor.Thumb == "" && course.Primary2x3 != "" {
-				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
-			}
+			// Use local portrait filename (downloaded alongside NFO)
+			actor.Thumb = sanitizeFilename(inst.Name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}
@@ -1728,10 +1710,8 @@ func writeEpisodeNFO(chapter Chapter, course CourseResponse, outputDir string, n
 				Name: name,
 				Role: "Instructor",
 			}
-			// Use poster as fallback for actor thumb
-			if course.Primary2x3 != "" {
-				actor.Thumb = course.Primary2x3 + "?width=500&height=500&fit=cover&dpr=2"
-			}
+			// Use local portrait filename
+			actor.Thumb = sanitizeFilename(name) + ".jpg"
 			actors = append(actors, actor)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -929,8 +929,10 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 	}
 
 	classSlug = strings.TrimPrefix(classSlug, "https://www.masterclass.com/classes/")
+	classSlug = strings.TrimPrefix(classSlug, "https://www.masterclass.com/series/")
 	classSlug = strings.TrimSuffix(classSlug, "/")
 	chapterSlug = strings.TrimPrefix(chapterSlug, "https://www.masterclass.com/classes/")
+	chapterSlug = strings.TrimPrefix(chapterSlug, "https://www.masterclass.com/series/")
 	chapterSlug = strings.TrimSuffix(chapterSlug, "/")
 	if classSlug == "" {
 		return fmt.Errorf("invalid class slug")

--- a/main.go
+++ b/main.go
@@ -1063,7 +1063,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 		// Create CycleTLS client once for all chapters (avoid memory leak)
 		cycleclient := cycletls.Init()
 		defer func() {
-			recover() // CycleTLS Close() can panic, ignore it
+			defer func() { recover() }() // Catch panic from Close()
 			cycleclient.Close()
 		}()
 

--- a/main.go
+++ b/main.go
@@ -938,8 +938,8 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 		return fmt.Errorf("invalid class slug")
 	}
 
-	//get class info (include=instructors ensures we get full instructor data for series)
-	req, err := http.NewRequest("GET", "https://www.masterclass.com/jsonapi/v1/courses/"+classSlug+"?deep=true&include=instructors", nil)
+	//get class info (include=instructors,chapters ensures we get full data for series)
+	req, err := http.NewRequest("GET", "https://www.masterclass.com/jsonapi/v1/courses/"+classSlug+"?deep=true&include=instructors,chapters", nil)
 	req.Header.Set("Referer", "https://www.masterclass.com/classes/"+classSlug)
 	req.Header.Set("Mc-Profile-Id", profile.UUID)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ Supported URL formats:
 			if !downloadPdfs && !metadataOnly {
 				fmt.Println("--pdfs=false specified, skipping PDF downloads")
 			}
-			if !downloadPosters {
+			if !downloadPosters && !metadataOnly {
 				fmt.Println("--posters=false specified, skipping poster/fanart downloads")
 			}
 			if limit != 10 {

--- a/main.go
+++ b/main.go
@@ -1046,7 +1046,8 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 				return fmt.Errorf("failed to download PDF")
 			}
 			fmt.Printf("Downloading: %s\n", pdfTitle)
-			pdfFile, err := os.Create(path.Join(outputDir, pdfTitle+".pdf"))
+			safePdfTitle := sanitizeFilename(pdfTitle)
+			pdfFile, err := os.Create(path.Join(outputDir, safePdfTitle+".pdf"))
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	var writeNfo bool
 	var metadataOnly bool
 	var forceDownload bool
+	var concurrency int
 	var downloadCmd = &cobra.Command{
 		Use:     "download [class/chapter/category...]",
 		Aliases: []string{"dl"},
@@ -98,12 +99,12 @@ Supported URL formats:
 			for _, arg := range args {
 				// Check if this is a category/homepage URL
 				if strings.Contains(arg, "/homepage/") {
-					err := downloadCategory(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, limit, nameAsSeries, writeNfo, metadataOnly, forceDownload, arg)
+					err := downloadCategory(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, limit, nameAsSeries, writeNfo, metadataOnly, forceDownload, concurrency, arg)
 					if err != nil {
 						fmt.Println(err)
 					}
 				} else {
-					err := download(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, arg)
+					err := download(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, concurrency, arg)
 					if err != nil {
 						fmt.Println(err)
 					}
@@ -120,6 +121,7 @@ Supported URL formats:
 	downloadCmd.Flags().BoolVar(&writeNfo, "write-nfo", false, "Write tvshow.nfo metadata file for Plex/Jellyfin")
 	downloadCmd.Flags().BoolVar(&metadataOnly, "metadata-only", false, "Download only metadata (poster, fanart, NFO) - no videos or PDFs")
 	downloadCmd.Flags().BoolVar(&forceDownload, "force", false, "Re-download files even if they already exist")
+	downloadCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 1, "Number of concurrent fragment downloads for yt-dlp")
 	downloadCmd.MarkFlagRequired("output")
 
 	var loginCmd = &cobra.Command{
@@ -911,7 +913,7 @@ func showCategoryMetadata(client *http.Client, profileUUID string, jsonOutput bo
 	return nil
 }
 
-func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, arg string) error {
+func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, concurrency int, arg string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
 	}
@@ -1074,7 +1076,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 				continue
 			}
 			fmt.Printf("Downloading chapter %d: %s\n", chapter.Number, chapter.Title)
-			err := downloadChapter(cycleclient, client, profile.UUID, outputDir, ytdlExec, chapter, class, apiKey, nameAsSeries, writeNfo, forceDownload)
+			err := downloadChapter(cycleclient, client, profile.UUID, outputDir, ytdlExec, chapter, class, apiKey, nameAsSeries, writeNfo, forceDownload, concurrency)
 			if err != nil {
 				return err
 			}
@@ -1121,7 +1123,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 	return nil
 }
 
-func downloadCategory(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, limit int, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, arg string) error {
+func downloadCategory(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, limit int, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, concurrency int, arg string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
 	}
@@ -1234,7 +1236,7 @@ func downloadCategory(client *http.Client, datDir string, outputDir string, down
 		fmt.Printf("\n[%d/%d] Downloading: %s\n", i+1, downloadCount, course.Title)
 		fmt.Println(strings.Repeat("=", 60))
 
-		err := download(client, datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, course.Slug)
+		err := download(client, datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, concurrency, course.Slug)
 		if err != nil {
 			fmt.Printf("Error downloading %s: %v\n", course.Slug, err)
 			// Continue with next course instead of stopping
@@ -1246,7 +1248,7 @@ func downloadCategory(client *http.Client, datDir string, outputDir string, down
 	return nil
 }
 
-func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profileUUID string, outputDir string, ytdlExec string, chapter Chapter, course CourseResponse, apiKey string, nameAsSeries bool, writeNfo bool, forceDownload bool) error {
+func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profileUUID string, outputDir string, ytdlExec string, chapter Chapter, course CourseResponse, apiKey string, nameAsSeries bool, writeNfo bool, forceDownload bool, concurrency int) error {
 	// Build cookie string from jar - try getting from www.masterclass.com
 	wwwURL, _ := url.Parse("https://www.masterclass.com")
 	edgeURL, _ := url.Parse("https://edge.masterclass.com")
@@ -1387,6 +1389,7 @@ func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profile
 		"--embed-subs", "--all-subs",
 		"--embed-metadata",
 		"-f", "bestvideo+bestaudio",
+		"-N", fmt.Sprintf("%d", concurrency),
 		"--postprocessor-args", metadataArgs,
 		chapterMetadata.Sources[0].Src,
 		"-o", outputFile,

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	var nameAsSeries bool
 	var writeNfo bool
 	var metadataOnly bool
+	var forceDownload bool
 	var downloadCmd = &cobra.Command{
 		Use:     "download [class/chapter/category...]",
 		Aliases: []string{"dl"},
@@ -97,12 +98,12 @@ Supported URL formats:
 			for _, arg := range args {
 				// Check if this is a category/homepage URL
 				if strings.Contains(arg, "/homepage/") {
-					err := downloadCategory(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, limit, nameAsSeries, writeNfo, metadataOnly, arg)
+					err := downloadCategory(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, limit, nameAsSeries, writeNfo, metadataOnly, forceDownload, arg)
 					if err != nil {
 						fmt.Println(err)
 					}
 				} else {
-					err := download(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, arg)
+					err := download(getClient(datDir), datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, arg)
 					if err != nil {
 						fmt.Println(err)
 					}
@@ -118,6 +119,7 @@ Supported URL formats:
 	downloadCmd.Flags().BoolVar(&nameAsSeries, "name-files-as-series", false, "Name files in TV series format (s01e01-Title.mp4)")
 	downloadCmd.Flags().BoolVar(&writeNfo, "write-nfo", false, "Write tvshow.nfo metadata file for Plex/Jellyfin")
 	downloadCmd.Flags().BoolVar(&metadataOnly, "metadata-only", false, "Download only metadata (poster, fanart, NFO) - no videos or PDFs")
+	downloadCmd.Flags().BoolVar(&forceDownload, "force", false, "Re-download files even if they already exist")
 	downloadCmd.MarkFlagRequired("output")
 
 	var loginCmd = &cobra.Command{
@@ -909,7 +911,7 @@ func showCategoryMetadata(client *http.Client, profileUUID string, jsonOutput bo
 	return nil
 }
 
-func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, nameAsSeries bool, writeNfo bool, metadataOnly bool, arg string) error {
+func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, arg string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
 	}
@@ -1072,7 +1074,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 				continue
 			}
 			fmt.Printf("Downloading chapter %d: %s\n", chapter.Number, chapter.Title)
-			err := downloadChapter(cycleclient, client, profile.UUID, outputDir, ytdlExec, chapter, class, apiKey, nameAsSeries, writeNfo)
+			err := downloadChapter(cycleclient, client, profile.UUID, outputDir, ytdlExec, chapter, class, apiKey, nameAsSeries, writeNfo, forceDownload)
 			if err != nil {
 				return err
 			}
@@ -1119,7 +1121,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 	return nil
 }
 
-func downloadCategory(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, limit int, nameAsSeries bool, writeNfo bool, metadataOnly bool, arg string) error {
+func downloadCategory(client *http.Client, datDir string, outputDir string, downloadPdfs bool, downloadPosters bool, ytdlExec string, limit int, nameAsSeries bool, writeNfo bool, metadataOnly bool, forceDownload bool, arg string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
 	}
@@ -1232,7 +1234,7 @@ func downloadCategory(client *http.Client, datDir string, outputDir string, down
 		fmt.Printf("\n[%d/%d] Downloading: %s\n", i+1, downloadCount, course.Title)
 		fmt.Println(strings.Repeat("=", 60))
 
-		err := download(client, datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, course.Slug)
+		err := download(client, datDir, outputDir, downloadPdfs, downloadPosters, ytdlExec, nameAsSeries, writeNfo, metadataOnly, forceDownload, course.Slug)
 		if err != nil {
 			fmt.Printf("Error downloading %s: %v\n", course.Slug, err)
 			// Continue with next course instead of stopping
@@ -1244,7 +1246,7 @@ func downloadCategory(client *http.Client, datDir string, outputDir string, down
 	return nil
 }
 
-func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profileUUID string, outputDir string, ytdlExec string, chapter Chapter, course CourseResponse, apiKey string, nameAsSeries bool, writeNfo bool) error {
+func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profileUUID string, outputDir string, ytdlExec string, chapter Chapter, course CourseResponse, apiKey string, nameAsSeries bool, writeNfo bool, forceDownload bool) error {
 	// Build cookie string from jar - try getting from www.masterclass.com
 	wwwURL, _ := url.Parse("https://www.masterclass.com")
 	edgeURL, _ := url.Parse("https://edge.masterclass.com")
@@ -1333,6 +1335,14 @@ func downloadChapter(cycleclient cycletls.CycleTLS, client *http.Client, profile
 		baseFileName = fmt.Sprintf("%03d-%s", chapter.Number, sanitizeFilename(chapter.Title))
 	}
 	outputFile := path.Join(outputDir, baseFileName+".mp4")
+
+	// Check if output file already exists (skip unless --force)
+	if !forceDownload {
+		if _, err := os.Stat(outputFile); err == nil {
+			fmt.Printf("Skipping %s (already exists)\n", baseFileName+".mp4")
+			return nil
+		}
+	}
 
 	// Build metadata arguments - always embed full metadata regardless of naming mode
 	// Extract date (YYYY-MM-DD) from UpdatedAt

--- a/response_types.go
+++ b/response_types.go
@@ -412,3 +412,50 @@ type ChapterMetadataResponse struct {
 		MimeType string `json:"mime_type"`
 	} `json:"text_tracks"`
 }
+
+// ContentRowsResponse represents the response from /jsonapi/v3/content-rows
+type ContentRowsResponse []ContentRow
+
+type ContentRow struct {
+	ID    int           `json:"id"`
+	Slug  string        `json:"slug"`
+	UUID  string        `json:"uuid"`
+	Items []ContentItem `json:"items"`
+}
+
+type ContentItem struct {
+	TileType string             `json:"tile_type"`
+	ItemUUID string             `json:"item_uuid"`
+	Default  ContentItemDefault `json:"default"`
+}
+
+type ContentItemDefault struct {
+	TileType        string              `json:"tile_type"`
+	Title           string              `json:"title"`
+	Subtitle        string              `json:"subtitle"`
+	Caption         string              `json:"caption"`
+	Duration        string              `json:"duration"`
+	Images          ContentItemImages   `json:"images"`
+	Resource        ContentItemResource `json:"resource"`
+	TileRedirect    string              `json:"tile_click_redirect"`
+	TopRightPill    *ContentItemPill    `json:"top_right_pill"`
+	BottomRightPill *ContentItemPill    `json:"bottom_right_pill"`
+}
+
+type ContentItemImages struct {
+	Primary16x9 string `json:"primary_16x9"`
+	Primary2x3  string `json:"primary_2x3"`
+	Primary1x1  string `json:"primary_1x1"`
+}
+
+type ContentItemResource struct {
+	EntityType string `json:"entity_type"`
+	EntityID   int    `json:"entity_id"`
+	EntitySlug string `json:"entity_slug"`
+	EntityUUID string `json:"entity_uuid"`
+}
+
+type ContentItemPill struct {
+	Text string `json:"text"`
+	Kind string `json:"kind"`
+}


### PR DESCRIPTION
# Changes
(Also took liberty to add some README updates)

## Download posters and embed them into a video
- feat(download): add --posters flag to download posters and fanart images
- feat(download): implement downloading poster and fanart images using downloadImage helper
- feat(download): update download function signature to include downloadPosters flag
- feat(download): enhance yt-dlp command to embed metadata (title, description, episode_sort) into downloaded videos

## Download categories
- feat(main): support downloading all classes from a category URL with a new command flag --limit
- feat(main): update download command usage, help, and args to accept categories and explain supported URL formats
- feat(main): implement downloadCategory function to fetch category content rows from API and download multiple courses with optional limit
- feat(response_types): add ContentRowsResponse and related types to parse category content-rows API JSON response
- docs(README): add comprehensive usage instructions, examples, flags, and features for downloading categories and using the limit option
- docs(README): improve overall README structure with sections for features, installation, usage, flags, output structure, global flags, and commands