### PR TITLE
feat: add subs-only flag and series URL support

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,6 +719,12 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 }
 
 func downloadChapter(client *http.Client, profileUUID string, outputDir string, ytdlExec string, subsOnly bool, chapter Chapter, apiKey string) error {
+	// Skip chapters without video content (e.g., PDF-only chapters)
+	if chapter.MediaUUID == "" {
+		fmt.Printf("Skipping chapter %d: %s (no video content)\n", chapter.Number, chapter.Title)
+		return nil
+	}
+
 	// Use CycleTLS for the media metadata API request to bypass any Cloudflare protection
 	cycleclient := cycletls.Init()
 	// Don't close cycleclient - it causes a panic and isn't necessary for short-lived processes
@@ -795,6 +801,12 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 	err = json.Unmarshal([]byte(metadataResp.Body), &chapterMetadata)
 	if err != nil {
 		return fmt.Errorf("failed to parse metadata: %v", err)
+	}
+
+	// Check if there are video sources available
+	if len(chapterMetadata.Sources) == 0 {
+		fmt.Printf("Skipping chapter %d: %s (no video sources)\n", chapter.Number, chapter.Title)
+		return nil
 	}
 
 	var cmd *exec.Cmd

--- a/main.go
+++ b/main.go
@@ -620,19 +620,26 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 
 	classSlug := ""
 	chapterSlug := ""
+	// Handle both /chapters/ (classes) and /episodes/ (series) URL patterns
 	if strings.Contains(arg, "/chapters/") {
 		classSlug = strings.Split(arg, "/chapters/")[0]
 		chapterSlug = strings.Split(arg, "/chapters/")[1]
+	} else if strings.Contains(arg, "/episodes/") {
+		classSlug = strings.Split(arg, "/episodes/")[0]
+		chapterSlug = strings.Split(arg, "/episodes/")[1]
 	} else {
 		classSlug = arg
 	}
 
+	// Strip URL prefixes for both classes and series
 	classSlug = strings.TrimPrefix(classSlug, "https://www.masterclass.com/classes/")
+	classSlug = strings.TrimPrefix(classSlug, "https://www.masterclass.com/series/")
+	classSlug = strings.TrimPrefix(classSlug, "classes/")
+	classSlug = strings.TrimPrefix(classSlug, "series/")
 	classSlug = strings.TrimSuffix(classSlug, "/")
-	chapterSlug = strings.TrimPrefix(chapterSlug, "https://www.masterclass.com/classes/")
 	chapterSlug = strings.TrimSuffix(chapterSlug, "/")
 	if classSlug == "" {
-		return fmt.Errorf("invalid class slug")
+		return fmt.Errorf("invalid class/series slug")
 	}
 
 	//get class info

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 	var outputDir string
 	var downloadPdfs bool
 	var ytdlExec string
+	var subsOnly bool
 	var downloadCmd = &cobra.Command{
 		Use:     "download [class/chapter...]",
 		Aliases: []string{"dl"},
@@ -61,7 +62,7 @@ func main() {
 		Args:    cobra.MatchAll(cobra.MinimumNArgs(1)),
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, arg := range args {
-				err := download(getClient(datDir), datDir, outputDir, downloadPdfs, ytdlExec, arg)
+				err := download(getClient(datDir), datDir, outputDir, downloadPdfs, ytdlExec, subsOnly, arg)
 				if err != nil {
 					fmt.Println(err)
 				}
@@ -71,6 +72,7 @@ func main() {
 	downloadCmd.Flags().StringVarP(&outputDir, "output", "o", "", "Output directory")
 	downloadCmd.Flags().BoolVarP(&downloadPdfs, "pdfs", "p", true, "Download PDFs")
 	downloadCmd.Flags().StringVarP(&ytdlExec, "ytdl-exec", "y", "yt-dlp", "Path to the youtube-dl or yt-dlp executable")
+	downloadCmd.Flags().BoolVarP(&subsOnly, "subs-only", "s", false, "Download only subtitles (no video)")
 	downloadCmd.MarkFlagRequired("output")
 
 	var loginCmd = &cobra.Command{
@@ -606,7 +608,7 @@ func loginStatus(client *http.Client, datDir string) error {
 	return nil
 }
 
-func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, ytdlExec string, arg string) error {
+func download(client *http.Client, datDir string, outputDir string, downloadPdfs bool, ytdlExec string, subsOnly bool, arg string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
 	}
@@ -698,7 +700,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 			continue
 		}
 		fmt.Printf("Downloading chapter %d: %s\n", chapter.Number, chapter.Title)
-		err := downloadChapter(client, profile.UUID, outputDir, ytdlExec, chapter, apiKey)
+		err := downloadChapter(client, profile.UUID, outputDir, ytdlExec, subsOnly, chapter, apiKey)
 		if err != nil {
 			return err
 		}
@@ -709,7 +711,7 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 	return nil
 }
 
-func downloadChapter(client *http.Client, profileUUID string, outputDir string, ytdlExec string, chapter Chapter, apiKey string) error {
+func downloadChapter(client *http.Client, profileUUID string, outputDir string, ytdlExec string, subsOnly bool, chapter Chapter, apiKey string) error {
 	// Use CycleTLS for the media metadata API request to bypass any Cloudflare protection
 	cycleclient := cycletls.Init()
 	// Don't close cycleclient - it causes a panic and isn't necessary for short-lived processes
@@ -788,7 +790,12 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 		return fmt.Errorf("failed to parse metadata: %v", err)
 	}
 
-	cmd := exec.Command(ytdlExec, "--embed-subs", "--all-subs", "-f", "bestvideo+bestaudio", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s.mp4", chapter.Number, chapter.Title)))
+	var cmd *exec.Cmd
+	if subsOnly {
+		cmd = exec.Command(ytdlExec, "--skip-download", "--write-subs", "--all-subs", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s", chapter.Number, chapter.Title)))
+	} else {
+		cmd = exec.Command(ytdlExec, "--embed-subs", "--all-subs", "-f", "bestvideo+bestaudio", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s.mp4", chapter.Number, chapter.Title)))
+	}
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/Danny-Dasilva/CycleTLS/cycletls"
@@ -17,6 +18,32 @@ import (
 	"github.com/spf13/cobra"
 	"go.nhat.io/cookiejar"
 )
+
+// sanitizeFilename removes or replaces characters that are illegal in filenames.
+// On Windows: < > : " / \ | ? *
+// Also handles characters that are problematic across platforms.
+func sanitizeFilename(name string) string {
+	// Characters to replace (illegal on Windows, problematic elsewhere)
+	replacer := strings.NewReplacer(
+		"?", "#",
+		":", "#",
+		"<", "",
+		">", "",
+		"\"", "'",
+		"/", "-",
+		"\\", "-",
+		"|", "-",
+		"*", "",
+	)
+	result := replacer.Replace(name)
+
+	// On Windows, also handle trailing dots and spaces which are problematic
+	if runtime.GOOS == "windows" {
+		result = strings.TrimRight(result, ". ")
+	}
+
+	return result
+}
 
 // Common constants for requests
 const (
@@ -552,6 +579,32 @@ func getProfile(client *http.Client, datDir string) (*ProfileResponse, error) {
 	return &profile, nil
 }
 
+func fetchChapter(client *http.Client, profileUUID string, chapterID int) (*Chapter, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://www.masterclass.com/jsonapi/v1/chapters/%d?deep=true", chapterID), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Referer", "https://www.masterclass.com/")
+	req.Header.Set("Mc-Profile-Id", profileUUID)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch chapter: status %d", resp.StatusCode)
+	}
+
+	var chapter Chapter
+	err = json.NewDecoder(resp.Body).Decode(&chapter)
+	if err != nil {
+		return nil, err
+	}
+	return &chapter, nil
+}
+
 func loginStatus(client *http.Client, datDir string) error {
 	if (client.Jar.Cookies(&url.URL{Scheme: "https", Host: "www.masterclass.com"}) == nil) {
 		return fmt.Errorf("cookies not found. Please login first")
@@ -657,21 +710,47 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("failed to get class info")
 	}
-	var class CourseResponse
-	err = json.NewDecoder(resp.Body).Decode(&class)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
-	outputDir = path.Join(outputDir, class.Title)
+	var class CourseResponse
+	err = json.Unmarshal(bodyBytes, &class)
+	if err != nil {
+		return err
+	}
+
+	// Handle shallow chapters (API returns only {"id": ...} for some courses)
+	// In this case, we need to fetch full chapter data individually
+	if len(class.Chapters) > 0 && class.Chapters[0].Slug == "" {
+		fmt.Println("Detected shallow chapter data, fetching full chapter details...")
+		for i, ch := range class.Chapters {
+			if ch.ID == 0 {
+				continue
+			}
+			fullChapter, err := fetchChapter(client, profile.UUID, ch.ID)
+			if err != nil {
+				fmt.Printf("  Warning: failed to fetch chapter %d: %v\n", ch.ID, err)
+				continue
+			}
+			class.Chapters[i] = *fullChapter
+		}
+	}
+
+	outputDir = path.Join(outputDir, sanitizeFilename(class.Title))
 	err = os.MkdirAll(outputDir, 0755)
 	if err != nil {
 		return err
 	}
 
 	if downloadPdfs {
-		fmt.Println("Downloading PDFs")
+		fmt.Printf("Downloading PDFs (%d found)\n", len(class.AllPDFs))
 		for _, pdf := range class.AllPDFs {
+			fmt.Printf("  PDF: %s (URL: %s)\n", pdf.Title, pdf.URL)
+			if pdf.URL == "" {
+				continue
+			}
 			req, err := http.NewRequest("GET", pdf.URL, nil)
 			if err != nil {
 				return err
@@ -700,31 +779,209 @@ func download(client *http.Client, datDir string, outputDir string, downloadPdfs
 
 	// Masterclass uses a fixed API key for media metadata requests
 	apiKey := "b9517f7d8d1f48c2de88100f2c13e77a9d8e524aed204651acca65202ff5c6cb9244c045795b1fafda617ac5eb0a6c50"
-	fmt.Printf("Using API key\n")
 
+	if chapterSlug != "" {
+		fmt.Printf("Looking for chapter slug: %s\n", chapterSlug)
+	}
+	fmt.Printf("Found %d chapters:\n", len(class.Chapters))
+	for _, ch := range class.Chapters {
+		fmt.Printf("  Chapter %d: %s (slug: %s)\n", ch.Number, ch.Title, ch.Slug)
+	}
+
+	downloadedCount := 0
 	for _, chapter := range class.Chapters {
 		if chapterSlug != "" && chapter.Slug != chapterSlug {
 			continue
 		}
 		fmt.Printf("Downloading chapter %d: %s\n", chapter.Number, chapter.Title)
-		err := downloadChapter(client, profile.UUID, outputDir, ytdlExec, subsOnly, chapter, apiKey)
+		downloaded, err := downloadChapter(client, profile.UUID, outputDir, ytdlExec, subsOnly, chapter, apiKey)
 		if err != nil {
 			return err
 		}
+		if downloaded {
+			downloadedCount++
+		}
 	}
 
-	fmt.Println("Done")
+	if subsOnly {
+		fmt.Printf("Done - %d subtitle(s) downloaded successfully\n", downloadedCount)
+	} else {
+		fmt.Printf("Done - %d chapter(s) downloaded successfully\n", downloadedCount)
+	}
 
 	return nil
 }
 
-func downloadChapter(client *http.Client, profileUUID string, outputDir string, ytdlExec string, subsOnly bool, chapter Chapter, apiKey string) error {
+// getChapterStreamInfo fetches the stream URL and text tracks for a chapter
+func getChapterStreamInfo(client *http.Client, profileUUID string, mediaUUID string, apiKey string) (string, []TextTrack, error) {
+	// Use CycleTLS for the media metadata API request to bypass any Cloudflare protection
+	cycleclient := cycletls.Init()
+
+	// Build cookie string from jar
+	wwwURL, _ := url.Parse("https://www.masterclass.com")
+	edgeURL, _ := url.Parse("https://edge.masterclass.com")
+
+	wwwCookies := client.Jar.Cookies(wwwURL)
+	edgeCookies := client.Jar.Cookies(edgeURL)
+
+	cookieMap := make(map[string]string)
+	for _, c := range edgeCookies {
+		cookieMap[c.Name] = c.Value
+	}
+	for _, c := range wwwCookies {
+		cookieMap[c.Name] = c.Value
+	}
+
+	var cookieStr string
+	first := true
+	for name, value := range cookieMap {
+		if !first {
+			cookieStr += "; "
+		}
+		cookieStr += name + "=" + value
+		first = false
+	}
+
+	metadataResp, err := cycleclient.Do("https://edge.masterclass.com/api/v1/media/metadata/"+mediaUUID, cycletls.Options{
+		Body:      "",
+		Ja3:       ja3,
+		UserAgent: userAgent,
+		Headers: map[string]string{
+			"Accept":             "application/json",
+			"Accept-Language":    "en-US,en;q=0.9",
+			"Content-Type":       "application/json",
+			"Origin":             "https://www.masterclass.com",
+			"Referer":            "https://www.masterclass.com/",
+			"Mc-Profile-Id":      profileUUID,
+			"X-Api-Key":          apiKey,
+			"Cookie":             cookieStr,
+			"Sec-Fetch-Dest":     "empty",
+			"Sec-Fetch-Mode":     "cors",
+			"Sec-Fetch-Site":     "same-site",
+			"Sec-Ch-Ua":          `"Chromium";v="141", "Not?A_Brand";v="8"`,
+			"Sec-Ch-Ua-Mobile":   "?0",
+			"Sec-Ch-Ua-Platform": `"macOS"`,
+		},
+	}, "GET")
+
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to fetch metadata: %v", err)
+	}
+
+	if metadataResp.Status != 200 {
+		return "", nil, fmt.Errorf("failed to get chapter metadata: status=%d", metadataResp.Status)
+	}
+
+	var chapterMetadata ChapterMetadataResponse
+	err = json.Unmarshal([]byte(metadataResp.Body), &chapterMetadata)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse metadata: %v", err)
+	}
+
+	var streamURL string
+	if len(chapterMetadata.Sources) > 0 {
+		streamURL = chapterMetadata.Sources[0].Src
+	}
+
+	return streamURL, chapterMetadata.TextTracks, nil
+}
+
+func downloadChapter(client *http.Client, profileUUID string, outputDir string, ytdlExec string, subsOnly bool, chapter Chapter, apiKey string) (bool, error) {
 	// Skip chapters without video content (e.g., PDF-only chapters)
 	if chapter.MediaUUID == "" {
 		fmt.Printf("Skipping chapter %d: %s (no video content)\n", chapter.Number, chapter.Title)
-		return nil
+		return false, nil
 	}
 
+	// For subs-only mode, try TextTracks first (faster), fall back to yt-dlp
+	if subsOnly {
+		safeTitle := sanitizeFilename(chapter.Title)
+		baseFilename := path.Join(outputDir, fmt.Sprintf("%03d-%s", chapter.Number, safeTitle))
+
+		// Get stream info from metadata API
+		streamURL, textTracks, err := getChapterStreamInfo(client, profileUUID, chapter.MediaUUID, apiKey)
+		if err != nil {
+			fmt.Printf("  Warning: failed to get stream info: %v\n", err)
+		}
+
+		// Prefer TextTracks from metadata API, fall back to chapter data
+		tracks := textTracks
+		if len(tracks) == 0 {
+			tracks = chapter.TextTracks
+		}
+
+		// First, try direct TextTracks download (faster than yt-dlp)
+		downloadedSubs := 0
+		if len(tracks) > 0 {
+			for _, track := range tracks {
+				if track.Src == "" {
+					continue
+				}
+				// Create filename with language code
+				subFilename := fmt.Sprintf("%s.%s.vtt", baseFilename, track.SrcLang)
+
+				// Download the VTT file directly
+				resp, err := http.Get(track.Src)
+				if err != nil {
+					fmt.Printf("  Warning: failed to download %s subtitle: %v\n", track.Label, err)
+					continue
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != 200 {
+					fmt.Printf("  Warning: failed to download %s subtitle: status %d\n", track.Label, resp.StatusCode)
+					continue
+				}
+
+				subFile, err := os.Create(subFilename)
+				if err != nil {
+					fmt.Printf("  Warning: failed to create subtitle file for %s: %v\n", track.Label, err)
+					continue
+				}
+
+				_, err = io.Copy(subFile, resp.Body)
+				subFile.Close()
+				if err != nil {
+					fmt.Printf("  Warning: failed to write subtitle file for %s: %v\n", track.Label, err)
+					continue
+				}
+
+				fmt.Printf("  Downloaded subtitle: %s (%s)\n", track.Label, track.SrcLang)
+				downloadedSubs++
+			}
+		}
+
+		if downloadedSubs > 0 {
+			return true, nil
+		}
+
+		// Fallback: try yt-dlp subtitle extraction (works if subs are in HLS manifest)
+		if streamURL != "" {
+			fmt.Printf("  TextTracks empty, trying yt-dlp fallback...\n")
+			cmd := exec.Command(ytdlExec, "--skip-download", "--write-subs", "--all-subs", "-o", baseFilename+".%(ext)s", streamURL)
+			// Suppress yt-dlp output - it can crash on some URLs due to regex bugs
+			cmd.Run()
+
+			// Check if yt-dlp produced any subtitle files
+			entries, _ := os.ReadDir(outputDir)
+			for _, entry := range entries {
+				name := entry.Name()
+				if strings.HasPrefix(name, fmt.Sprintf("%03d-%s", chapter.Number, safeTitle)) &&
+					(strings.HasSuffix(name, ".vtt") || strings.HasSuffix(name, ".srt") || strings.HasSuffix(name, ".ass")) {
+					fmt.Printf("  Downloaded subtitle via yt-dlp: %s\n", name)
+					downloadedSubs++
+				}
+			}
+		}
+
+		if downloadedSubs == 0 {
+			fmt.Printf("Skipping chapter %d: %s (no subtitles available from any source)\n", chapter.Number, chapter.Title)
+			return false, nil
+		}
+		return true, nil
+	}
+
+	// For video download, we need the metadata API to get the stream URL
 	// Use CycleTLS for the media metadata API request to bypass any Cloudflare protection
 	cycleclient := cycletls.Init()
 	// Don't close cycleclient - it causes a panic and isn't necessary for short-lived processes
@@ -736,8 +993,6 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 	// Get cookies from both URLs and merge them
 	wwwCookies := client.Jar.Cookies(wwwURL)
 	edgeCookies := client.Jar.Cookies(edgeURL)
-
-	fmt.Printf("Debug: www cookies: %d, edge cookies: %d\n", len(wwwCookies), len(edgeCookies))
 
 	// Build a map to collect unique cookies, preferring www cookies
 	cookieMap := make(map[string]string)
@@ -757,13 +1012,6 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 		cookieStr += name + "=" + value
 		first = false
 	}
-
-	// Debug: show what we're sending
-	fmt.Printf("Media metadata request:\n")
-	fmt.Printf("  URL: https://edge.masterclass.com/api/v1/media/metadata/%s\n", chapter.MediaUUID)
-	fmt.Printf("  Mc-Profile-Id: %s\n", profileUUID)
-	fmt.Printf("  X-Api-Key: %s\n", apiKey)
-	fmt.Printf("  Cookie header length: %d\n", len(cookieStr))
 
 	metadataResp, err := cycleclient.Do("https://edge.masterclass.com/api/v1/media/metadata/"+chapter.MediaUUID, cycletls.Options{
 		Body:      "",
@@ -788,37 +1036,34 @@ func downloadChapter(client *http.Client, profileUUID string, outputDir string, 
 	}, "GET")
 
 	if err != nil {
-		return fmt.Errorf("failed to fetch metadata: %v", err)
+		return false, fmt.Errorf("failed to fetch metadata: %v", err)
 	}
 
 	if metadataResp.Status != 200 {
 		fmt.Printf("Response status: %d\n", metadataResp.Status)
 		fmt.Printf("Response body: %s\n", metadataResp.Body[:min(len(metadataResp.Body), 500)])
-		return fmt.Errorf("failed to get chapter metadata: status=%d", metadataResp.Status)
+		return false, fmt.Errorf("failed to get chapter metadata: status=%d", metadataResp.Status)
 	}
 
 	var chapterMetadata ChapterMetadataResponse
 	err = json.Unmarshal([]byte(metadataResp.Body), &chapterMetadata)
 	if err != nil {
-		return fmt.Errorf("failed to parse metadata: %v", err)
+		return false, fmt.Errorf("failed to parse metadata: %v", err)
 	}
 
 	// Check if there are video sources available
 	if len(chapterMetadata.Sources) == 0 {
 		fmt.Printf("Skipping chapter %d: %s (no video sources)\n", chapter.Number, chapter.Title)
-		return nil
+		return false, nil
 	}
 
-	var cmd *exec.Cmd
-	if subsOnly {
-		cmd = exec.Command(ytdlExec, "--skip-download", "--write-subs", "--all-subs", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s", chapter.Number, chapter.Title)))
-	} else {
-		cmd = exec.Command(ytdlExec, "--embed-subs", "--all-subs", "-f", "bestvideo+bestaudio", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s.mp4", chapter.Number, chapter.Title)))
-	}
+	// Download video with embedded subs
+	safeTitle := sanitizeFilename(chapter.Title)
+	cmd := exec.Command(ytdlExec, "--embed-subs", "--all-subs", "-f", "bestvideo+bestaudio", chapterMetadata.Sources[0].Src, "-o", path.Join(outputDir, fmt.Sprintf("%03d-%s.mp4", chapter.Number, safeTitle)))
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
 	if err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return true, nil
 }

--- a/response_types.go
+++ b/response_types.go
@@ -391,6 +391,16 @@ type Chapter struct {
 	Season              interface{}   `json:"season"`
 	ChaptersInstructors []interface{} `json:"chapters_instructors"`
 	Instructors         []interface{} `json:"instructors"`
+	TextTracks          []TextTrack   `json:"text_tracks"`
+}
+
+type TextTrack struct {
+	Src      string `json:"src"`
+	SrcLang  string `json:"srclang"`
+	Label    string `json:"label"`
+	Kind     string `json:"kind"`
+	Default  bool   `json:"default"`
+	MimeType string `json:"mime_type"`
 }
 
 type ChapterMetadataResponse struct {
@@ -403,12 +413,5 @@ type ChapterMetadataResponse struct {
 		Type  string `json:"type"`
 		Src   string `json:"src"`
 	}
-	TextTracks []struct {
-		Src      string `json:"src"`
-		SrcLang  string `json:"srclang"`
-		Label    string `json:"label"`
-		Kind     string `json:"kind"`
-		Default  bool   `json:"default"`
-		MimeType string `json:"mime_type"`
-	} `json:"text_tracks"`
+	TextTracks []TextTrack `json:"text_tracks"`
 }


### PR DESCRIPTION
## Summary

- Add `--subs-only` / `-s` flag to download only subtitles without video
- Support series/episodes URL format in addition to classes/chapters

## Changes

### 1. Subtitle-only download (`--subs-only`)
When enabled, runs yt-dlp with `--skip-download --write-subs --all-subs` instead of downloading the full video.

```bash
masterclass-dl download course-slug -o output -s
```

### 2. Series URL support
Now handles both URL patterns:
- `/classes/{slug}/chapters/{chapter}` (existing)
- `/series/{slug}/episodes/{episode}` (new)

Also strips `classes/` and `series/` prefixes when provided without full URL.

## Test plan

- [ ] Test `--subs-only` flag downloads .vtt files without video
- [ ] Test series URL like `series/financial-wellness/episodes/your-money-psychology`
- [ ] Test classes URL still works as before