### PR TITLE
Fix memory leak, silent failures, and security issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ Supported URL formats:
 func getClient(datDir string) *http.Client {
 	jar := cookiejar.NewPersistentJar(
 		cookiejar.WithFilePath(path.Join(datDir, "cookies.json")),
-		cookiejar.WithFilePerm(0755),
+		cookiejar.WithFilePerm(0600),
 		cookiejar.WithAutoSync(true),
 	)
 
@@ -238,9 +238,6 @@ func login(client *http.Client, datDir string, email string, password string, de
 	if debug {
 		fmt.Printf("Attempting login with email: %s\n", email)
 		fmt.Printf("Password length: %d characters\n", len(password))
-		if len(password) > 0 {
-			fmt.Printf("Password first char: %c, last char: %c\n", password[0], password[len(password)-1])
-		}
 	}
 
 	// First, visit the home page to establish session (required for login to work)
@@ -1360,6 +1357,10 @@ func downloadCategory(client *http.Client, datDir string, outputDir string, down
 func getChapterStreamInfo(client *http.Client, profileUUID string, mediaUUID string, apiKey string) (string, []TextTrack, error) {
 	// Use CycleTLS for the media metadata API request to bypass any Cloudflare protection
 	cycleclient := cycletls.Init()
+	defer func() {
+		defer func() { recover() }() // Catch panic from Close()
+		cycleclient.Close()
+	}()
 
 	// Build cookie string from jar
 	wwwURL, _ := url.Parse("https://www.masterclass.com")
@@ -1501,8 +1502,10 @@ func downloadChapterSubsOnly(client *http.Client, profileUUID string, outputDir 
 	if streamURL != "" {
 		fmt.Printf("  TextTracks empty, trying yt-dlp fallback...\n")
 		cmd := exec.Command(ytdlExec, "--skip-download", "--write-subs", "--all-subs", "-o", baseFilename+".%(ext)s", streamURL)
-		// Suppress yt-dlp output - it can crash on some URLs due to regex bugs
-		cmd.Run()
+		// yt-dlp can crash on some URLs due to regex bugs, so treat errors as non-fatal
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("  Warning: yt-dlp subtitle extraction failed: %v\n", err)
+		}
 
 		// Check if yt-dlp produced any subtitle files
 		entries, _ := os.ReadDir(outputDir)


### PR DESCRIPTION
## Summary

Fixes 4 critical issues found during code audit:

- **Memory leak**: `getChapterStreamInfo()` creates a CycleTLS client (`main.go:1362`) but never closes it. Each call leaks a goroutine and connection — called once per chapter in subs-only mode. Added `defer Close()` with panic recovery (matching the existing pattern at line 1167).
- **Silent yt-dlp failure**: In subtitle-only mode, `cmd.Run()` error was completely ignored (`main.go:1505`). Users received no feedback when subtitle extraction failed. Now logs a warning.
- **Cookie file permissions**: `cookiejar.WithFilePerm(0755)` made session cookies world-readable. Changed to `0600` (user-only).
- **Password logging**: Debug mode logged the first and last character of the password (`main.go:240-242`), which could be captured in logs. Removed.

## Test plan

- [x] `go build` compiles cleanly
- [x] `go vet ./...` passes
- [x] `./masterclass-dl status` — login/cookie reading works
- [x] `./masterclass-dl download -s -o ./test-dl "<url>"` — subs-only mode works (exercises memory leak fix + yt-dlp error handling)
- [x] Cookie file created with correct `0600` permissions