### PR TITLE
Fix password exposure in command-line arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,10 +156,32 @@ Supported URL formats:
 	var loginCmd = &cobra.Command{
 		Use:   "login [email] [password]",
 		Short: "Login to masterclass.com",
-		Args:  cobra.ExactArgs(2),
+		Long: `Login to masterclass.com with your email and password.
+
+Password is resolved in this order:
+  1. Command-line argument (not recommended — visible in shell history and process list)
+  2. MASTERCLASS_PASSWORD environment variable
+  3. Interactive secure prompt (recommended)`,
+		Args: cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			email := args[0]
-			password := args[1]
+			var password string
+			if len(args) >= 2 {
+				password = args[1]
+			} else if envPass := os.Getenv("MASTERCLASS_PASSWORD"); envPass != "" {
+				password = envPass
+			} else {
+				prompt := promptui.Prompt{
+					Label: "Password",
+					Mask:  '*',
+				}
+				var err error
+				password, err = prompt.Run()
+				if err != nil {
+					fmt.Printf("Error reading password: %v\n", err)
+					return
+				}
+			}
 			err := login(getClient(datDir), datDir, email, password, debug)
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
Closes #7

## Summary

The `login` command previously required the password as a positional CLI argument (`masterclass-dl login <email> <password>`), which exposed it in:
- **Shell history** (`~/.bash_history`, `~/.zsh_history`)
- **Process list** (`ps aux`, `top`)

Password is now **optional** as a CLI argument and resolved in order:

1. **CLI argument** — kept for backward compatibility (not recommended)
2. **`MASTERCLASS_PASSWORD` environment variable** — for scripts/CI
3. **Interactive secure prompt** — recommended, input masked with `*`

Uses `promptui.Prompt` with `Mask: '*'` for hidden input — already a project dependency (used for profile selection).

### Before
```bash
masterclass-dl login user@example.com MySecretPass123  # visible everywhere
```

### After
```bash
masterclass-dl login user@example.com
# Password: ****
```

Or via environment variable:
```bash
export MASTERCLASS_PASSWORD=MySecretPass123
masterclass-dl login user@example.com
```

## Test plan

- [x] `go build` and `go vet` pass
- [x] `./masterclass-dl login --help` shows updated usage with password resolution order
- [x] `./masterclass-dl login email@example.com` prompts for password interactively with masked input
- [x] `./masterclass-dl login email@example.com password` still works (backward compatible)
- [x] `MASTERCLASS_PASSWORD=x ./masterclass-dl login email@example.com` reads from env var